### PR TITLE
hs/react-testing-integration

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -5,6 +5,7 @@ import {
   fireEvent,
   act,
 } from '@testing-library/react';
+import axios from 'axios';
 
 import App, {
   storiesReducer,
@@ -13,6 +14,8 @@ import App, {
   SearchForm,
   InputWithLabel,
 } from './App';
+
+jest.mock('axios');
 
 const storyOne = {
   title: 'React',
@@ -114,5 +117,145 @@ describe('SearchForm', () => {
     fireEvent.submit(screen.getByRole('button'));
 
     expect(searchFormProps.onSearchSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('App', () => {
+  test('succeeds fetching data', async () => {
+    const promise = Promise.resolve({
+      data: {
+        hits: stories,
+      },
+    });
+
+    axios.get.mockImplementationOnce(() => promise);
+
+    render(<App />);
+
+    expect(screen.queryByText(/Loading/)).toBeInTheDocument();
+
+    await act(() => promise);
+
+    expect(screen.queryByText(/Loading/)).toBeNull();
+
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('Redux')).toBeInTheDocument();
+    expect(screen.getAllByText('Dismiss').length).toBe(2);
+  });
+
+  test('fails fetching data', async () => {
+    const promise = Promise.reject();
+
+    axios.get.mockImplementationOnce(() => promise);
+
+    render(<App />);
+
+    expect(screen.queryByText(/Loading/)).toBeInTheDocument();
+
+    try {
+      await act(() => promise);
+    } catch (error) {
+      expect(screen.queryByText(/Loading/)).toBeNull();
+      expect(screen.queryByText(/went wrong/)).toBeInTheDocument();
+    }
+  });
+
+  test('removes a story', async () => {
+    const promise = Promise.resolve({
+      data: {
+        hits: stories,
+      },
+    });
+
+    axios.get.mockImplementationOnce(() => promise);
+
+    render(<App />);
+
+    await act(() => promise);
+
+    expect(screen.getAllByText('Dismiss').length).toBe(2);
+    expect(screen.getByText('Jordan Walke')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByText('Dismiss')[0]);
+
+    expect(screen.getAllByText('Dismiss').length).toBe(1);
+    expect(screen.queryByText('Jordan Walke')).toBeNull();
+  });
+
+  test('searches for specific stories', async () => {
+    const reactPromise = Promise.resolve({
+      data: {
+        hits: stories,
+      },
+    });
+
+    const anotherStory = {
+      title: 'JavaScript',
+      url: 'https://en.wikipedia.org/wiki/JavaScript',
+      author: 'Brendan Eich',
+      num_comments: 15,
+      points: 10,
+      objectID: 3,
+    };
+
+    const javascriptPromise = Promise.resolve({
+      data: {
+        hits: [anotherStory],
+      },
+    });
+
+    axios.get.mockImplementation(url => {
+      if (url.includes('React')) {
+        return reactPromise;
+      }
+
+      if (url.includes('JavaScript')) {
+        return javascriptPromise;
+      }
+
+      throw Error();
+    });
+
+    // Initial Render
+
+    render(<App />);
+
+    // First Data Fetching
+
+    await act(() => reactPromise);
+
+    expect(screen.queryByDisplayValue('React')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('JavaScript')).toBeNull();
+
+    expect(screen.queryByText('Jordan Walke')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Dan Abramov, Andrew Clark')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Brendan Eich')).toBeNull();
+
+    // User Interaction -> Search
+
+    fireEvent.change(screen.queryByDisplayValue('React'), {
+      target: {
+        value: 'JavaScript',
+      },
+    });
+
+    expect(screen.queryByDisplayValue('React')).toBeNull();
+    expect(
+      screen.queryByDisplayValue('JavaScript')
+    ).toBeInTheDocument();
+
+    fireEvent.submit(screen.queryByText('Submit'));
+
+    // Second Data Fetching
+
+    await act(() => javascriptPromise);
+
+    expect(screen.queryByText('Jordan Walke')).toBeNull();
+    expect(
+      screen.queryByText('Dan Abramov, Andrew Clark')
+    ).toBeNull();
+    expect(screen.queryByText('Brendan Eich')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
There is a something wrong with the promise in the last part as you made reactPromise for example looking like this:
`const reactPromise = Promise.resolve({
      data: {
        hits: stories,
      },
    });
`
While you should provide page in the data object as it is being used in the Reducer uses the page variable in the logic, this produces an error in the tests which shouldn't because it concatenates data instead of re-assigning the new list of data.

This 
`const reactPromise = Promise.resolve({
      data: {
        page: 0,
        hits: stories,
      },
    });
`
The same case should be done with javascriptPromise.