### PR TITLE
Use nullish coalescing operator in custom hook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const useSemiPersistentState = (key, initialState) => {
   const [value, setValue] = React.useState(
-    localStorage.getItem(key) || initialState
+    localStorage.getItem(key) ?? initialState
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
I found a bug whenever I cleared the search input and refreshed - it would reset to the initialState. Using the nullish coalescing operator instead of the boolean OR operator fixed it.